### PR TITLE
APIMF-2387: changed ascii 'NULL' (value 0) character encode to unicode equivalent '\u0000' so it is compatible with the JSON character set.

### DIFF
--- a/shared/src/main/scala/org/mulesoft/common/core/package.scala
+++ b/shared/src/main/scala/org/mulesoft/common/core/package.scala
@@ -93,24 +93,26 @@ package object core {
           if (ch < 32) {
             out += '\\'
             ch match {
-              case '\b' => out += 'b'
-              case '\n' => out += 'n'
-              case '\t' => out += 't'
-              case '\f' => out += 'f'
-              case '\r' => out += 'r'
-              case 0    => out += '0'
-              case _    => out ++= "u00" + (if (ch > 0xf) "" else "0") + ch.toHexString
+              case '\b'                => out += 'b'
+              case '\n'                => out += 'n'
+              case '\t'                => out += 't'
+              case '\f'                => out += 'f'
+              case '\r'                => out += 'r'
+              case _                   => out ++= "u00" + (if (ch > 0xf) "" else "0") + ch.toHexString
             }
-          } else if (ch < 0x7F) {
+          }
+          else if (ch < 0x7F) {
             if (ch == '"' || ch == '\\') out += '\\'
             out += ch
-          } else if (encodeNonAscii) {
+          }
+          else if (encodeNonAscii) {
             out ++= "\\u"
             if (ch <= 0xfff) {
               if (ch > 0xff) out += '0' else out ++= "00"
             }
             out ++= ch.toHexString
-          } else {
+          }
+          else {
             out += ch
           }
           f += 1

--- a/shared/src/test/scala/org/mulesoft/common/core/CoreTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/core/CoreTest.scala
@@ -43,7 +43,7 @@ trait CoreTest extends FunSuite with Matchers {
   test("encoded strings") {
     "ab\"c".encode shouldBe "ab\\\"c"
 
-    val code = "a\\u00F3\\\\\\b\\n\\r\\t\\fpi\\u03A0\\u13A0\\0quote\\\"\\u0001\\u001F"
+    val code = "a\\u00F3\\\\\\b\\n\\r\\t\\fpi\\u03A0\\u13A0\\u0000quote\\\"\\u0001\\u001F"
     code.decode shouldBe "aó\\\b\n\r\t\fpi\u03A0\u13A0\u0000quote\"\u0001\u001F"
     val encoded = code.decode.encode
     encoded shouldBe code
@@ -52,6 +52,10 @@ trait CoreTest extends FunSuite with Matchers {
   test("encoded non ascii strings") {
     "こんにちは".encode(encodeNonAscii = false) shouldBe "こんにちは"
     "こんにちは".encode shouldBe "\\u3053\\u3093\\u306B\\u3061\\u306F"
+  }
+
+  test("decode ascii nul character") {
+    Char.MinValue.toString.decode.encode shouldBe "\\u0000"
   }
 
   test("extended decode") {


### PR DESCRIPTION
Encoding the ascii character 'NUL' (ascii code 0) as '\0' leads to invalid JSON output. This is why I changed the encode to it's '\u000' equivalent.