### PR TITLE
W-13191540: bump to ScalaJS 1.6 & Scala 2.12.15 & SBT 1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.1
+FROM ghcr.io/aml-org/amf-ci-tools-base-image:1.3.2

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtsonar.SonarPlugin.autoImport.sonarProperties
 
 ThisBuild / version := getVersion(1, 1)
 ThisBuild / scalacOptions ++= Seq("-feature")
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := "2.12.15"
 
 lazy val common = crossProject(JSPlatform, JVMPlatform)
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val common = crossProject(JSPlatform, JVMPlatform)
           organization := "org.mule.common",
           name := "scala-common",
           libraryDependencies ++= Seq(
-              "org.scalactic" %%% "scalactic" % "3.0.1" % Test,
-              "org.scalatest" %%% "scalatest" % "3.0.0" % Test
+              "org.scalactic" %%% "scalactic" % "3.2.13" % Test,
+              "org.scalatest" %%% "scalatest" % "3.2.13" % Test
           ),
           credentials ++= Common.credentials()
       )

--- a/build.sbt
+++ b/build.sbt
@@ -12,16 +12,15 @@ lazy val common = crossProject(JSPlatform, JVMPlatform)
           organization := "org.mule.common",
           name := "scala-common",
           libraryDependencies ++= Seq(
-              "org.scalactic" %%% "scalactic" % "3.2.13" % Test,
-              "org.scalatest" %%% "scalatest" % "3.2.13" % Test
+              "org.scalactic" %%% "scalactic" % "3.2.0" % Test,
+              "org.scalatest" %%% "scalatest" % "3.2.0" % Test
           ),
           credentials ++= Common.credentials()
       )
   )
-  .jvmSettings(libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided")
+  .jvmSettings(libraryDependencies += "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided")
   .jsSettings(
-      scalaJSModuleKind := ModuleKind.CommonJSModule,
-      scalacOptions += "-P:scalajs:suppressExportDeprecations"
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
 
 lazy val commonJVM = common.jvm.in(file("./jvm"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.33")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.6.0")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "2.0.4")
 addSbtPlugin("com.sonar-scala"    % "sbt-sonar"                % "2.3.0")

--- a/shared/src/main/scala/org/mulesoft/common/io/Output.scala
+++ b/shared/src/main/scala/org/mulesoft/common/io/Output.scala
@@ -58,7 +58,7 @@ object Output {
   implicit def stringBufferWriter[W <: LimitedStringBuffer]: Output[W] = StringBufferWriter.asInstanceOf[Output[W]]
 }
 
-@JSExportTopLevel("org.mulesoft.common.io.LimitedStringBuffer")
+@JSExportTopLevel("LimitedStringBuffer")
 case class LimitedStringBuffer(limit: Int) {
 
   private val buf: StringBuffer = new StringBuffer()
@@ -77,5 +77,5 @@ case class LimitedStringBuffer(limit: Int) {
 }
 
 @JSExportAll
-@JSExportTopLevel("org.mulesoft.common.io.LimitReachedException")
+@JSExportTopLevel("LimitReachedException")
 case class LimitReachedException() extends Exception()

--- a/shared/src/test/scala/org/mulesoft/common/collections/FilterTypeTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/collections/FilterTypeTest.scala
@@ -1,9 +1,9 @@
 package org.mulesoft.common.collections
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-trait FilterTypeTest extends FunSuite {
+trait FilterTypeTest extends AnyFunSuite with Matchers {
   test("Test simple type filtering") {
     sealed trait Letter
     case class A() extends Letter

--- a/shared/src/test/scala/org/mulesoft/common/core/CachedFunctionTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/core/CachedFunctionTest.scala
@@ -1,10 +1,10 @@
 package org.mulesoft.common.core
 
 import org.mulesoft.common.functional.MonadInstances._
-import org.scalatest.AsyncFunSuite
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
 
-trait CachedFunctionTest extends AsyncFunSuite {
+trait CachedFunctionTest extends AsyncFunSuite with Matchers {
   test("Cache proxy with context") {
     val operation                                   = (f: Float) => Option(Math.nextUp(f))
     val proxy: CachedFunction[Float, Float, Option] = CachedFunction.fromMonadic(operation)

--- a/shared/src/test/scala/org/mulesoft/common/core/CoreTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/core/CoreTest.scala
@@ -1,13 +1,12 @@
 package org.mulesoft.common.core
 
-import org.scalatest.{FunSuite, Matchers}
-
-import org.mulesoft.common.core._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Test Core Methods.
   */
-trait CoreTest extends FunSuite with Matchers {
+trait CoreTest extends AnyFunSuite with Matchers {
 
   test("basic strings") {
     val s1 = "aaaxxxa"

--- a/shared/src/test/scala/org/mulesoft/common/io/IoAsyncTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/io/IoAsyncTest.scala
@@ -1,6 +1,6 @@
 package org.mulesoft.common.io
 
-import org.scalatest.AsyncFunSuite
+import org.scalatest.funsuite.AsyncFunSuite
 
 import scala.concurrent.ExecutionContext
 

--- a/shared/src/test/scala/org/mulesoft/common/io/IoTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/io/IoTest.scala
@@ -1,17 +1,18 @@
 package org.mulesoft.common.io
 
 import java.io.StringWriter
-
 import org.mulesoft.common.io.Output._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Assertion, FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Assertion
 
 import scala.language.higherKinds
 
 /**
   * IO Tests
   */
-trait IoTest extends FunSuite with BaseIoTest {
+trait IoTest extends AnyFunSuite with BaseIoTest {
 
   test("read") {
     val dataDir = fs.syncFile(dirName)

--- a/shared/src/test/scala/org/mulesoft/common/lexical/PositionTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/lexical/PositionTest.scala
@@ -1,13 +1,14 @@
 package org.mulesoft.common.lexical
 
-import org.mulesoft.common.client.lexical.{Position, SourceLocation}
 import org.mulesoft.common.client.lexical.Position.ZERO
-import org.scalatest.{FunSuite, Matchers}
+import org.mulesoft.common.client.lexical.{Position, SourceLocation}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Test Builders
  */
-trait PositionTest extends FunSuite with Matchers {
+trait PositionTest extends AnyFunSuite with Matchers {
 
   test("Position by Offset") {
     val a = Position(10)

--- a/shared/src/test/scala/org/mulesoft/common/net/NetTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/net/NetTest.scala
@@ -1,12 +1,13 @@
 package org.mulesoft.common.net
 
 import org.mulesoft.common.parse.ParseException
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Test Core Methods.
   */
-trait NetTest extends FunSuite with Matchers {
+trait NetTest extends AnyFunSuite with Matchers {
 
   test("inet address") {
     import InetAddress._

--- a/shared/src/test/scala/org/mulesoft/common/time/SimpleDateTimeTest.scala
+++ b/shared/src/test/scala/org/mulesoft/common/time/SimpleDateTimeTest.scala
@@ -2,12 +2,14 @@ package org.mulesoft.common.time
 
 import org.mulesoft.common.parse._
 import org.mulesoft.common.time.SimpleDateTime._
-import org.scalatest.{FunSuite, Matchers, OptionValues}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 
 /**
   * Check SimpleDateTime
   */
-trait SimpleDateTimeTest extends FunSuite with Matchers with OptionValues {
+trait SimpleDateTimeTest extends AnyFunSuite with Matchers with OptionValues {
   test("singletons") {
     Epoch.day shouldBe 1
     Epoch.month shouldBe 1


### PR DESCRIPTION
- chore: bumped ScalaTest libraries to 3.2.13
- (breaking): removed namespaces from LimitReachedException and LimitedStringBuffer classes
- W-13191540: bumped to ScalaJS 1.6. Had to lower test libraries because they were incompatible with ScalaJS 1.6
